### PR TITLE
Do not ignore components placed in `node_modules`

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -21,5 +21,5 @@ export default () => addHook(
       ]
     }).code
   },
-  { exts: ['.riot'] }
+  { exts: ['.riot'], ignoreNodeModules: false }
 )


### PR DESCRIPTION
By default pirates ignores `node_modules`. If components were installed from an npm repository SSR wouldn't work.